### PR TITLE
sensible changes to string types

### DIFF
--- a/dataParser.js
+++ b/dataParser.js
@@ -18,8 +18,7 @@ function parseNode(text, prefixes) {
         return RDF.RDFLiteral(
             N3Util.getLiteralValue(text),
             RDF.LangTag(N3Util.getLiteralLanguage(text)),
-            //TODO fix this hackery to fix where N3Utils gives a type when not explicitly declared which RDF.js doesn't like
-            (text.indexOf("^^") > -1)?RDF.IRI(N3Util.getLiteralType(text)):undefined
+            RDF.IRI(N3Util.getLiteralType(text))
         );
     }
     else if (N3Util.isIRI(text)) {

--- a/tests/alasdairs_hcls.shex
+++ b/tests/alasdairs_hcls.shex
@@ -17,8 +17,8 @@ start = <SummaryLevelShape>
 
 <SummaryLevelShape> {
     rdf:type (dctypes:Dataset),
-    dct:title xsd:string,  ### should be rdf:langString
-    dct:description xsd:string, ### should be rdf:langString
+    dct:title rdf:langString,  ### should be rdf:langString
+    dct:description rdf:langString, ### should be rdf:langString
 ###negate dct:created .,
 ###negate pav:createdOn .,
 ###negate pav:authoredOn .,
@@ -68,8 +68,8 @@ start = <SummaryLevelShape>
 
 <VersionLevelShape> {
     rdf:type (dctypes:Dataset),
-    dct:title xsd:string,  ### should be rdf:langString
-    dct:description xsd:string, ### should be rdf:langString
+    dct:title rdf:langString,  ### should be rdf:langString
+    dct:description rdf:langString, ### should be rdf:langString
     # Ensure that at least one of created or issued dates is provided
     (dct:created xsd:dateTime, dct:issued xsd:dateTime? |
         dct:created xsd:dateTime?, dct:issued xsd:dateTime),
@@ -115,8 +115,8 @@ start = <SummaryLevelShape>
 
 <DistributionLevelShape> {
     rdf:type (dctypes:Dataset),
-    dct:title xsd:string,  ### should be rdf:langString
-    dct:description xsd:string, ### should be rdf:langString
+    dct:title rdf:langString,  ### should be rdf:langString
+    dct:description rdf:langString, ### should be rdf:langString
     # Ensure that at least one of created or issued dates is provided
     (dct:created xsd:dateTime, dct:issued xsd:dateTime? |
         dct:created xsd:dateTime?, dct:issued xsd:dateTime),
@@ -155,8 +155,8 @@ start = <SummaryLevelShape>
 
 <RDFDistributionLevelShape> {
     rdf:type (void:Dataset),
-    dct:title xsd:string,  ### should be rdf:langString
-    dct:description xsd:string, ### should be rdf:langString
+    dct:title rdf:langString,  ### should be rdf:langString
+    dct:description rdf:langString, ### should be rdf:langString
     # Ensure that at least one of created or issued dates is provided
     (dct:created xsd:dateTime, dct:issued xsd:dateTime? |
         dct:created xsd:dateTime?, dct:issued xsd:dateTime),


### PR DESCRIPTION
Does anyone know why xsd:string was being used?

rdf:langString certainly lets us lose the hackery in dataParser.js

@Doix any ideas?